### PR TITLE
feat: add OCP yaml + onpremEnv var support in classpath yaml

### DIFF
--- a/hyperexecute_linux_snooper_specific_tags_ocp.yaml
+++ b/hyperexecute_linux_snooper_specific_tags_ocp.yaml
@@ -1,24 +1,23 @@
 version: 0.1
 runson: linux
 
-onpremEnv: ${onpremEnv}
+onpremEnv: ocp-pre-prod
 
 autosplit: true
-concurrency: 3
+concurrency: 2
 
 alwaysRunPostSteps: true
 
 testDiscovery:
   type: raw
   mode: remote
-  command: echo "classpath:nested/features/Main.feature"
+  command: snooper --featureFilePaths=src/test/resources/apis/features --frameWork=java  --specificTags=@CreateNewUser @GetRequest
 
 testRunnerCommand: |
   echo "Running test: $test"
-  gradle test --tests APIRunner -Dkarate.options="$test"
+  gradle test --tests APIRunner  -Dkarate.options=$test -d
 
-
-jobLabel: ['Karate', 'Gradle', "ClassPath"]
+jobLabel: ['Karate', 'Snooper-remote', 'Gradle', 'ocp-pre-prod']
 
 scenarioCommandStatusOnly: true
 # For API scenarios to avoid marking of skip after execution
@@ -34,7 +33,7 @@ uploadArtefacts:
       - target/
   - name: Karate Report
     path:
-      - build/karate-reports/
+        - build/karate-reports/
 
 cacheKey: '{{ checksum "build.gradle" }}'
 cacheDirectories:
@@ -45,5 +44,5 @@ pre:
   - gradle dependencies --refresh-dependencies --gradle-user-home=.gradle --no-daemon
 
 runtime:
-  language: java
-  version: 11
+    language: java
+    version: 11


### PR DESCRIPTION
## Summary
- New `hyperexecute_linux_snooper_specific_tags_ocp.yaml` with `onpremEnv: ocp-pre-prod` baked in
- Updated `hyperexecute_linux_classpath.yaml` with `onpremEnv: ${onpremEnv}` for dynamic env injection via workflow vars
- Used by LTQAAutomation OCP test scenarios (PR LambdatestIncPrivate/LTQAAutomation#7473)

🤖 Generated with [Claude Code](https://claude.com/claude-code)